### PR TITLE
Allow pulling git-lfs files in Azure CI

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -27,6 +27,7 @@ jobs:
 
       steps:
         - checkout: self
+          lfs: true
           submodules: ${{ coalesce(parameters.submodules, true) }}
           fetchDepth: 999999999
         - ${{ if not(eq(target, 'wheels_windows')) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -56,6 +56,7 @@ jobs:
 
         steps:
         - checkout: self
+          lfs: true
           submodules: ${{ coalesce(parameters.submodules, true) }}
           fetchDepth: 999999999
 


### PR DESCRIPTION
We ran into the issue of Azure not pulling git-lfs files during
https://github.com/PlasmaPy/PlasmaPy-NEI/pull/21

As it turns out, adding `lfs: true` to the `checkout` step
as in this change:

https://github.com/PlasmaPy/PlasmaPy-NEI/pull/21/commits/d3360c3cba0fe95e949ec7d0cc35495c7929e8c1

allows Azure to easily grab them.

This change was guided by Azure docs over at
https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/pipeline-options-for-git?view=azure-devops#checkout-files-from-lfs

---

I didn't see any easy way of overriding this setting downstream, and I currently see no disadvantages to putting it in upstream.