### PR TITLE
Make sure compilers work fine inside tox on MacOS X

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ jobs:
     - linux32: py37-simple-linux32
     - macos: py37-simple-macos
     - windows: py37-simple-windows
+    - macos: compiler_macos_conda
 
 - template: run-tox-env.yml
   parameters:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -153,6 +153,9 @@ jobs:
             ${{ if eq(variables.xvfb, 'true') }}:
               env:
                 DISPLAY: :99.0
+            ${{ if and(eq(env_pair.key, 'macos'),contains(env_pair.value, 'conda')) }}:
+              env:
+                CONDA_BUILD_SYSROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
         - ${{ if eq(coalesce(env['coverage'], parameters.coverage), 'codecov') }}:
           - script: |

--- a/test.c
+++ b/test.c
@@ -1,0 +1,2 @@
+#include<stdio.h>
+int main() {}

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,9 @@ commands = pytest test.py
 [testenv:compiler_macos_conda]
 # This is a test to make sure that compilers work properly on MacOS X
 # when installed from conda (which requires CONDA_BUILD_SYSROOT to be set)
-whitelist_externals:
-    /bin/echo
 passenv:
     CONDA_BUILD_SYSROOT
 conda_deps:
     clang_osx-64==10
 commands:
-    /bin/echo "#include<stdio.h>\nint main() {}" > test.c
     clang-10 test.c

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
   opengl-linux
   opengl-macos
   opengl-windows
+  compiler_macos_conda
 
 requires = pip >= 18.0
            setuptools >= 30.3.0
@@ -19,3 +20,16 @@ deps =
     opengl: vispy
     opengl: PyQt5
 commands = pytest test.py
+
+[testenv:compiler_macos_conda]
+# This is a test to make sure that compilers work properly on MacOS X
+# when installed from conda (which requires CONDA_BUILD_SYSROOT to be set)
+whitelist_externals:
+    /bin/echo
+passenv:
+    CONDA_BUILD_SYSROOT
+conda_deps:
+    clang_osx-64==10
+commands:
+    /bin/echo "#include<stdio.h>\nint main() {}" > test.c
+    clang-10 test.c


### PR DESCRIPTION
This should hopefully avoiding having to hard-code ``CONDA_BUILD_SYSROOT`` in https://github.com/astropy/extension-helpers/pull/22