### PR TITLE
Change the job friendly name to use the name variable if it exists

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,8 @@ jobs:
 - template: run-tox-env.yml
   parameters:
     envs:
-    - linux: py37-simple-linux
+    - linux: py37-simple-linux 
+      name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
     - macos: py37-simple-macos
     - windows: py37-simple-windows

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -11,7 +11,7 @@ jobs:
 
       - job: ${{ coalesce(env['name'], variables['Agent.Id']) }}
         variables:
-          friendly_name: '${{ env_pair.value }} [${{ env_pair.key }}]'
+          friendly_name: '${{ coalesce(env.name, env_pair.value) }} [${{ env_pair.key }}]'
           posargs: ${{ coalesce(env['posargs'], parameters.posargs) }}
           toxdeps: ${{ coalesce(env['toxdeps'], parameters.toxdeps) }}
           toxargs: ${{ coalesce(env['toxargs'], parameters.toxargs) }}


### PR DESCRIPTION
Currently, the job friendly name doesn't use the `name` variable even if it is specified.  For example, if the `azure-pipelines.yml` looks like:
```
envs:
- macos: py38
  name: py38_n4
  posargs: -n=4

- macos: py38
  name: py38_n1
  posargs: -n=1
```
the two jobs will have the same friendly name: "py38 [macos]".  Having the same friendly name is unhelpful on the Azure Pipelines website (because it's difficult to distinguish jobs) and horrible on GitHub (because if multiple jobs have the same friendly name, only one is shown).

This PR changes the friendly name to use the `name` variable if it is specified.  In the example above, the friendly names would be "py38_n4 [macos]" and "py38_n1 [macos]".
