### PR TITLE
Update codecov support

### DIFF
--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -164,8 +164,8 @@ jobs:
               python -m codecov --name "${{ variables.friendly_name }}"
             displayName: Running codecov
             condition: succeededOrFailed()
-            env:
-              CODECOV_TOKEN: $(CODECOV_TOKEN)
+            #env:
+            #  CODECOV_TOKEN: $(CODECOV_TOKEN)
 
         - task: PublishTestResults@2
           condition: succeededOrFailed()

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -165,8 +165,9 @@ jobs:
               script: bash <(curl -s https://codecov.io/bash)
             displayName: Running codecov
             condition: succeededOrFailed()
-            env:
-              CODECOV_TOKEN: $(CODECOV_TOKEN)
+            ${{ if ne(variables.CODECOV_TOKEN, '') }}:
+              env:
+                CODECOV_TOKEN: $(CODECOV_TOKEN)
 
         - task: PublishTestResults@2
           condition: succeededOrFailed()

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -160,8 +160,7 @@ jobs:
 
         - ${{ if eq(coalesce(env['coverage'], parameters.coverage), 'codecov') }}:
           - script: |
-              python -m pip install --upgrade codecov
-              python -m codecov --name "${{ variables.friendly_name }}"
+              bash <(curl -s https://codecov.io/bash)
             displayName: Running codecov
             condition: succeededOrFailed()
             #env:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -163,8 +163,8 @@ jobs:
               bash <(curl -s https://codecov.io/bash)
             displayName: Running codecov
             condition: succeededOrFailed()
-            #env:
-            #  CODECOV_TOKEN: $(CODECOV_TOKEN)
+            env:
+              CODECOV_TOKEN: $(CODECOV_TOKEN)
 
         - task: PublishTestResults@2
           condition: succeededOrFailed()

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -159,8 +159,10 @@ jobs:
                 CONDA_BUILD_SYSROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
         - ${{ if eq(coalesce(env['coverage'], parameters.coverage), 'codecov') }}:
-          - script: |
-              bash <(curl -s https://codecov.io/bash)
+          - task: Bash@3
+            inputs:
+              targetType: 'inline'
+              script: bash <(curl -s https://codecov.io/bash)
             displayName: Running codecov
             condition: succeededOrFailed()
             env:


### PR DESCRIPTION
Azure pipelines got first rate codecov support now, so I updated the templates to not need any token nonsense.

This is mostly based off of https://devblogs.microsoft.com/devops/uploading-to-codecov-just-got-easier/

I haven't actually tested what happens if you *do* have `CODECOV_TOKEN` set, but if it's a private repo you will need it.