### PR TITLE
Update to use python-build CLI over pep517

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -89,12 +89,12 @@ jobs:
       - ${{ each library in parameters.libraries }}:
         - script: sudo apt-get install -y ${{ library }}
           displayName: Installing ${{ library }} with apt
-      - script: 'python -m pip install -U --user --force-reinstall pep517 setuptools_scm'
+      - script: 'python -m pip install -U --user --force-reinstall build setuptools_scm'
         displayName: "Install build tools"
       - ${{ if parameters.remove_local_scheme }}:
           - bash: echo "##vso[task.setvariable variable=SETUPTOOLS_SCM_PRETEND_VERSION]$(python setup.py --version | cut -d '+' -f 1)"
             displayName: Remove local scheme from version
-      - script: 'python -m pep517.build --source --out-dir wheelhouse .'
+      - script: 'python -m build --sdist --outdir wheelhouse .'
         displayName: "Build source distribution"
       - ${{ if parameters.test_extras }}:
         - script: ${{ format('python -m pip install --force-reinstall $(find wheelhouse -name "*.tar.gz")[{0}]', parameters.test_extras) }}
@@ -123,12 +123,12 @@ jobs:
         displayName: setup python3.7
         inputs:
           versionSpec: '3.7'
-      - script: 'python -m pip install -U --user --force-reinstall pep517 setuptools_scm'
+      - script: 'python -m pip install -U --user --force-reinstall build setuptools_scm'
         displayName: "Install build tools"
       - ${{ if parameters.remove_local_scheme }}:
           - bash: echo "##vso[task.setvariable variable=SETUPTOOLS_SCM_PRETEND_VERSION]$(python setup.py --version | cut -d '+' -f 1)"
             displayName: Remove local scheme from version
-      - script: 'python -m pep517.build --binary --out-dir wheelhouse .'
+      - script: 'python -m build --wheel --outdir wheelhouse .'
         displayName: "Build universal wheel"
       - ${{ if parameters.test_extras }}:
         - script: ${{ format('python -m pip install --force-reinstall $(find wheelhouse -name "*.whl")[{0}]', parameters.test_extras) }}


### PR DESCRIPTION
It appears that pep517 want to [remove the frontend](https://github.com/pypa/pep517/pull/83) (CLI) and be a pure library, so [build](https://python-build.readthedocs.io/en/latest/) is basically the CLI it depends on pep517 for the magic.