### PR TITLE
Add support for arbitrary docker containers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,9 @@ jobs:
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python
+    - windows: py37-simple-windows
+      docker_image: winamd64/python
+      docker_python: /usr/local/bin/python
     - macos: py37-simple-macos
     - windows: py37-simple-windows
     - macos: compiler_macos_conda

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
     - linux32: py37-simple-linux32
     - linux32: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
-    - linux: py37-simple-linux
+    - linux: py38-simple-linux
       docker_image: python
       docker_python: /usr/local/bin/python
     - macos: py37-simple-macos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,9 @@ jobs:
     - linux: py37-simple-linux 
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
-    - linux32_manylinux2014_x86_64: py37-simple-linux
-      name: py37_simple_linux_manylinux_x86_64
+    - linux32: py37-simple-linux
+      manylinux_image: manylinux2014_x86_64
     - linux: py37-simple-linux
-      name: py37_simple_linux_docker_python
       docker_image: python
       docker_python: /usr/local/bin/python
     - macos: py37-simple-macos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,9 @@ jobs:
     - linux32: py38-simple-linux32
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
+      libraries:
+        yum:
+          - freetype-devel
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,13 +13,13 @@ jobs:
     - linux32: py37-simple-linux32
     - linux32: py38-simple-linux32
       libraries:
-        yum:
-          - openssl-devel
+      yum:
+        - openssl-devel
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
       libraries:
-        yum:
-          - openssl-devel
+      yum:
+        - openssl-devel
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ jobs:
     - linux: py37-simple-linux 
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
+    - linux32: py38-simple-linux32
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
     - linux: py39-simple-linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,13 +13,13 @@ jobs:
     - linux32: py37-simple-linux32
     - linux32: py38-simple-linux32
       libraries:
-      yum:
-        - openssl-devel
+        yum:
+          - openssl-devel
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
       libraries:
-      yum:
-        - openssl-devel
+        yum:
+          - openssl-devel
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,19 +7,16 @@ jobs:
 
 - template: run-tox-env.yml
   parameters:
+    libraries:
+      yum:
+        - openssl-devel
     envs:
     - linux: py37-simple-linux 
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
     - linux32: py38-simple-linux32
-      libraries:
-        yum:
-          - openssl-devel
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
-      libraries:
-        yum:
-          - openssl-devel
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     - linux: py37-simple-linux 
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
-    - linux32: py37-simple-linux
+    - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,10 @@ jobs:
     - linux: py37-simple-linux 
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
+    - linux32_manylinux2014_x86_64: py37-simple-linux
+    - linux: py37-simple-linux
+      docker_image: python:latest
+      docker_python: /usr/local/bin/python
     - macos: py37-simple-macos
     - windows: py37-simple-windows
     - macos: compiler_macos_conda

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
       name: py37_simple_linux_manylinux_x86_64
     - linux: py37-simple-linux
       name: py37_simple_linux_docker_python
-      docker_image: python:latest
+      docker_image: python
       docker_python: /usr/local/bin/python
     - macos: py37-simple-macos
     - windows: py37-simple-windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,8 @@ jobs:
     - linux32: py37-simple-linux32
     - linux32: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
-    - linux: py38-simple-linux
-      docker_image: python
+    - linux: py39-simple-linux
+      docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python
     - macos: py37-simple-macos
     - windows: py37-simple-windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,9 +17,6 @@ jobs:
     - linux32: py38-simple-linux32
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
-      libraries:
-        yum:
-          - freetype-devel
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,14 @@ jobs:
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
     - linux32: py38-simple-linux32
+      libraries:
+        yum:
+          - openssl-devel
     - manylinux: py37-simple-linux
       manylinux_image: manylinux2014_x86_64
+      libraries:
+        yum:
+          - openssl-devel
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,9 +20,6 @@ jobs:
     - linux: py39-simple-linux
       docker_image: python:3.9.0rc1-slim-buster
       docker_python: /usr/local/bin/python
-    - windows: py37-simple-windows
-      docker_image: winamd64/python
-      docker_python: /usr/local/bin/python
     - macos: py37-simple-macos
     - windows: py37-simple-windows
     - macos: compiler_macos_conda

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,9 @@ jobs:
       name: py37_simple_linux_custom_name
     - linux32: py37-simple-linux32
     - linux32_manylinux2014_x86_64: py37-simple-linux
+      name: py37_simple_linux_manylinux_x86_64
     - linux: py37-simple-linux
+      name: py37_simple_linux_docker_python
       docker_image: python:latest
       docker_python: /usr/local/bin/python
     - macos: py37-simple-macos

--- a/docs/run_tox_env.rst
+++ b/docs/run_tox_env.rst
@@ -288,6 +288,9 @@ Other Docker Images
 
 You can also specify your own docker images in which to run tox. There are a few
 options available to control this behaviour, they all can only be specified on a per-env basis.
+The running of the docker commands are not dependant on the operating system,
+although setting the os to ``linux32`` will cause all commands in the container
+to be prefixed with the ``linux32`` setarch binary.
 The following example shows all the possible options even though some are redundant:
 
 .. code:: yaml
@@ -304,5 +307,5 @@ The following example shows all the possible options even though some are redund
 The options are as follows:
 
 * ``docker_image`` this is the name of the container to be created. It can be any valid argument to ``docker pull``, i.e ``python`` or ``quay.io/pypa/manylinux2010_i686``.
-* ``docker_name`` this is optional as long as ``docker_image`` is a valid container name. If you specify a tag in ``docker_image`` ``:`` will be replaced, so you will not need to specify ``docker_name``. However, if you specify a URL style image you will need to manually specify the container name with ``docker_name``.
+* ``docker_name`` this is optional as long as ``docker_image`` is a valid container name. If you specify a tag in ``docker_image`` ``:`` and ``/`` will be replaced, so you will not need to specify ``docker_name``. However, if you specify a more complex image you will need to manually specify the container name with ``docker_name``.
 * ``docker_python`` this is the path inside the container to the docker executable.

--- a/docs/run_tox_env.rst
+++ b/docs/run_tox_env.rst
@@ -255,9 +255,50 @@ underscore
 Which is why they are not automatically set from the tox env names, as they
 frequently have hyphens in.
 
-Linux 32-bit
-------------
 
-When testing on 32-bit linux (i.e. with the OS set to ``linux32``, note that the
-Xvfb and conda options will not work. In addition, when using the ``libraries``
-parameter, you should use ``yum`` rather than ``apt`` as the tool name.
+Docker Jobs
+-----------
+
+This template has support for running tox inside docker containers. This was
+originally added to support testing against 32bit linux builds using the
+manylinux official docker images, so there is specific support for these images.
+When using docker the Xvfb, conda and libraries options will not work.
+
+Manylinux
+#########
+
+By setting the OS flag to ``manylinux`` (or ``linux32`` for backwards
+compatibility) the template will automatically select docker and use the
+``manylinux2010_i686`` image.
+
+When using ``manylinux`` images, the ``libraries`` parameter will work, and you
+should use ``yum`` rather than ``apt`` as the tool name.
+
+As a shortcut for the other docker options, when using ``manylinux`` you can set
+``manylinux_image`` to the name of the container you want to use. This excludes
+the ``quay.io/pypa`` prefix and also excludes any tag (``latest`` is always
+used).
+
+Other Docker Images
+###################
+
+You can also specify your own docker images in which to run tox. There are a few
+options available to control this behaviour, they all can only be specified on a per-env basis.
+The following example shows all the possible options even though some are redundant:
+
+.. code:: yaml
+
+    jobs:
+    - template: run-tox-env.yml@OpenAstronomy
+      parameters:
+        envs:
+        - linux: <job name>
+          docker_image: python:3.9.0rc1-slim-buster
+          docker_name: python39
+          docker_python: /usr/local/bin/python
+
+The options are as follows:
+
+* ``docker_image`` this is the name of the container to be created. It can be any valid argument to ``docker pull``, i.e ``python`` or ``quay.io/pypa/manylinux2010_i686``.
+* ``docker_name`` this is optional as long as ``docker_image`` is a valid container name. If you specify a tag in ``docker_image`` ``:`` will be replaced, so you will not need to specify ``docker_name``. However, if you specify a URL style image you will need to manually specify the container name with ``docker_name``.
+* ``docker_python`` this is the path inside the container to the docker executable.

--- a/docs/run_tox_env.rst
+++ b/docs/run_tox_env.rst
@@ -267,9 +267,13 @@ When using docker the Xvfb, conda and libraries options will not work.
 Manylinux
 #########
 
-By setting the OS flag to ``manylinux`` (or ``linux32`` for backwards
-compatibility) the template will automatically select docker and use the
-``manylinux2010_i686`` image.
+There are two options for using manylinux, you can set the os flag to either
+``linux32`` or ``manylinux``. If it is set to ``linux32`` all the commands will
+be prefixed with the ``linux32`` command to set the architecture to i686.
+
+By setting the OS flag to ``manylinux`` or ``linux32``, the template will
+automatically select docker and use the ``manylinux2010_i686`` image. Which can
+be overridden by specifying the ``manylinux_image`` parameter.
 
 When using ``manylinux`` images, the ``libraries`` parameter will work, and you
 should use ``yum`` rather than ``apt`` as the tool name.

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -38,6 +38,10 @@ jobs:
             python: '3.9'
 
           # Docker and manylinux
+          ${{ if eq(env_pair.key, 'linux32') }}:
+            setarch: 'linux32'
+          ${{ if not(eq(env_pair.key, 'linux32')) }}:
+            setarch: ''
           ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
             manylinux_container: ${{ coalesce(env['manylinux_image'], 'manylinux2010_i686') }}
             manylinux_image: ${{ format('quay.io/pypa/{0}:latest', variables.manylinux_container) }}
@@ -98,7 +102,7 @@ jobs:
                 displayName: Installing ${{ library }} with apt
 
             - ${{ if and(eq(tool_pair.key, 'yum'), or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux'))) }}:
-              - script: docker exec -i -w /project ${{ variables.docker_name }} toxrun yum install -y ${{ library }}
+              - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.setarch }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 
             - ${{ if and(eq(tool_pair.key, 'choco'), eq(env_pair.key, 'windows')) }}:
@@ -156,10 +160,10 @@ jobs:
 
         - ${{ if variables.docker_image }}:
 
-          - script: docker exec -i -w /project ${{ variables.docker_name }} toxrun ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
+          - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.setarch }} ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox
 
-          - script: docker exec -i -w /project ${{ variables.docker_name }} toxrun ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
+          - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.setarch }} ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
             displayName: Running tox
 
         - ${{ if not(variables.docker_image) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -98,7 +98,7 @@ jobs:
                 displayName: Installing ${{ library }} with apt
 
             - ${{ if and(eq(tool_pair.key, 'yum'), or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux'))) }}:
-              - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
+              - script: docker exec -i -w /project ${{ variables.docker_name }} toxrun yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 
             - ${{ if and(eq(tool_pair.key, 'choco'), eq(env_pair.key, 'windows')) }}:
@@ -156,10 +156,10 @@ jobs:
 
         - ${{ if variables.docker_image }}:
 
-          - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
+          - script: docker exec -i -w /project ${{ variables.docker_name }} toxrun ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox
 
-          - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
+          - script: docker exec -i -w /project ${{ variables.docker_name }} toxrun ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
             displayName: Running tox
 
         - ${{ if not(variables.docker_image) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ if eq(env_pair.key, 'linux32') }}:
             manylinux_image: 'manylinux2010_i686'
           manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
-          docker_python_exec: ${{ coalesce(parameters.docker_python, variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
+          docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
           docker_pull: ${{ coalesce(env['docker_pull'], env['docker_image'], format('quay.io/pypa/{0}:latest', variables.manylinux_image)) }}
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -19,25 +19,16 @@ jobs:
           xvfb: ${{ and(coalesce(env['xvfb'], parameters.xvfb, false), eq(env_pair.key, 'linux')) }}
           mesaopengl: ${{ and(coalesce(env['mesaopengl'], parameters.mesaopengl, false), eq(env_pair.key, 'windows')) }}
           pytest: ${{ or(eq(coalesce(env['pytest'], parameters.pytest), 'true'), contains(env_pair.value, 'test')) }}
-          default32bit: '/opt/python/cp27-cp27m/bin/python'
-          ${{ if startsWith(env_pair.value, 'py27') }}:
-            python: '2.7'
-            python32bit: '/opt/python/cp27-cp27m/bin/python'
-          ${{ if startsWith(env_pair.value, 'py34') }}:
-            python: '3.4'
-            python32bit: '/opt/python/cp34-cp34m/bin/python'
-          ${{ if startsWith(env_pair.value, 'py35') }}:
-            python: '3.5'
-            python32bit: '/opt/python/cp35-cp35m/bin/python'
-          ${{ if startsWith(env_pair.value, 'py36') }}:
-            python: '3.6'
-            python32bit: '/opt/python/cp36-cp36m/bin/python'
-          ${{ if startsWith(env_pair.value, 'py37') }}:
-            python: '3.7'
-            python32bit: '/opt/python/cp37-cp37m/bin/python'
-          ${{ if startsWith(env_pair.value, 'py38') }}:
-            python: '3.8'
-            python32bit: '/opt/python/cp38-cp38/bin/python'
+
+          # Docker and manylinux
+          ${{ if contains(env_pair.key, 'linux32_') }}:
+            manylinux_image: ${{ format('quay.io/pypa/{0}', replace(env_pair.key, 'linux32_', '')) }}
+          ${{ if eq(env_pair.key, 'linux32') }}:
+            manylinux_image: 'quay.io/pypa/manylinux2010_i686'
+          manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(env_pair.value, 'py', '')) }}
+          docker_python_exec: ${{ coalesce(parameters.docker_python, variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
+          docker_image: ${{ coalesce(parameters.docker_image, variables.manylinux_image, '') }}
+
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'
           ${{ if not(eq(env_pair.key, 'windows')) }}:
@@ -65,8 +56,8 @@ jobs:
           submodules: ${{ coalesce(parameters.submodules, true) }}
           fetchDepth: 999999999
 
-        - ${{ if eq(env_pair.key, 'linux32') }}:
-          - bash: docker run -v $PWD:/project -i --name manylinux2010 -d quay.io/pypa/manylinux2010_i686:latest /bin/bash
+        - ${{ if variables.docker_image }}:
+          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_image }} -d ${{ variables.docker_image }}:latest /bin/bash
             displayName: Start up Docker container
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:
@@ -85,7 +76,7 @@ jobs:
                 displayName: Installing ${{ library }} with apt
 
             - ${{ if and(eq(tool_pair.key, 'yum'), eq(env_pair.key, 'linux32')) }}:
-              - script: docker exec -i -w /project manylinux2010 linux32 yum install -y ${{ library }}
+              - script: docker exec -i -w /project ${{ variables.docker_image }} linux32 yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 
             - ${{ if and(eq(tool_pair.key, 'choco'), eq(env_pair.key, 'windows')) }}:
@@ -140,15 +131,15 @@ jobs:
           - script: python -m pip install --upgrade tox-conda ${{ variables.toxdeps }}
             displayName: install tox-conda
 
-        - ${{ if eq(env_pair.key, 'linux32') }}:
+        - ${{ if variables.docker_image }}:
 
-          - script: docker exec -i -w /project manylinux2010 linux32 ${{ coalesce(variables.python32bit, variables.default32bit) }} -m pip install --upgrade tox ${{ variables.toxdeps }}
+          - script: docker exec -i -w /project ${{ variables.docker_image }} linux32 ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox
 
-          - script: docker exec -i -w /project manylinux2010 linux32 ${{ coalesce(variables.python32bit, variables.default32bit) }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
+          - script: docker exec -i -w /project ${{ variables.docker_image }} linux32 ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
             displayName: Running tox
 
-        - ${{ if ne(env_pair.key, 'linux32') }}:
+        - ${{ if not(variables.docker_image) }}:
 
           - script: python -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -38,11 +38,13 @@ jobs:
 
           # Docker and manylinux
           ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
-            default_manylinux_image: 'manylinux2010_i686'
-          manylinux_image: ${{ coalesce(env['manylinux_image'], variables.default_manylinux_image, '') }}
+            default_manylinux_container: 'manylinux2010_i686'
+          manylinux_container: ${{ coalesce(env['manylinux_image'], variables.default_manylinux_container, '') }}
+          ${{ if variables.manylinux_container }}:
+            manylinux_image: format('quay.io/pypa/{0}:latest', variables.manylinux_container)
           manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
-          docker_image: ${{ coalesce(env['docker_image'], format('quay.io/pypa/{0}:latest', variables.manylinux_image), '') }}
+          docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
           docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinx_image) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -43,8 +43,8 @@ jobs:
             manylinux_image: 'manylinux2010_i686'
           manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(parameters.docker_python, variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
-          docker_image: ${{ coalesce(parameters.docker_image, variables.manylinux_image, '') }}
-          docker_pull: ${{ coalesce(parameters.docker_pull, format('quay.io/pypa/{0}', variables.manylinux_image), variables.docker_image) }}
+          docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
+          docker_pull: ${{ coalesce(env['docker_pull'], env['docker_image'], format('quay.io/pypa/{0}:latest', variables.manylinux_image)) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'
@@ -62,7 +62,7 @@ jobs:
         pool:
           ${{ if eq(env_pair.key, 'macos') }}:
             vmImage: macos-latest
-          ${{ if or(eq(env_pair.key, 'linux'), eq(env_pair.key, 'linux32')) }}:
+          ${{ if or(eq(env_pair.key, 'linux'), startsWith(env_pair.key, 'linux32')) }}:
             vmImage: ubuntu-latest
           ${{ if eq(env_pair.key, 'windows') }}:
             vmImage: windows-latest
@@ -74,7 +74,7 @@ jobs:
           fetchDepth: 999999999
 
         - ${{ if variables.docker_image }}:
-          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_image }} -d ${{ variables.docker_pull }}:latest /bin/bash
+          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_image }} -d ${{ variables.docker_pull }} /bin/bash
             displayName: Start up Docker container
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -8,7 +8,7 @@ jobs:
 - ${{ each env in parameters.envs }}:
   - ${{ each env_pair in env }}:
 
-    - ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'linux'), eq(env_pair.key, 'macos'), eq(env_pair.key, 'windows')) }}:
+    - ${{ if or(startsWith(env_pair.key, 'linux32'), eq(env_pair.key, 'linux'), eq(env_pair.key, 'macos'), eq(env_pair.key, 'windows')) }}:
 
       - job: ${{ coalesce(env['name'], variables['Agent.Id']) }}
         variables:
@@ -20,12 +20,28 @@ jobs:
           mesaopengl: ${{ and(coalesce(env['mesaopengl'], parameters.mesaopengl, false), eq(env_pair.key, 'windows')) }}
           pytest: ${{ or(eq(coalesce(env['pytest'], parameters.pytest), 'true'), contains(env_pair.value, 'test')) }}
 
+          # Setup python version
+          ${{ if startsWith(env_pair.value, 'py27') }}:
+            python: '2.7'
+          ${{ if startsWith(env_pair.value, 'py34') }}:
+            python: '3.4'
+          ${{ if startsWith(env_pair.value, 'py35') }}:
+            python: '3.5'
+          ${{ if startsWith(env_pair.value, 'py36') }}:
+            python: '3.6'
+          ${{ if startsWith(env_pair.value, 'py37') }}:
+            python: '3.7'
+          ${{ if startsWith(env_pair.value, 'py38') }}:
+            python: '3.8'
+          ${{ if startsWith(env_pair.value, 'py39') }}:
+            python: '3.9'
+
           # Docker and manylinux
           ${{ if contains(env_pair.key, 'linux32_') }}:
             manylinux_image: ${{ replace(env_pair.key, 'linux32_', '') }}
           ${{ if eq(env_pair.key, 'linux32') }}:
             manylinux_image: 'manylinux2010_i686'
-          manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(env_pair.value, 'py', '')) }}
+          manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(parameters.docker_python, variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(parameters.docker_image, variables.manylinux_image, '') }}
           docker_pull: ${{ coalesce(parameters.docker_pull, format('quay.io/pypa/{0}', variables.manylinux_image), variables.docker_image) }}

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -98,7 +98,7 @@ jobs:
               - script: sudo apt-get install -y ${{ library }}
                 displayName: Installing ${{ library }} with apt
 
-            - ${{ if and(eq(tool_pair.key, 'yum'), or(eq(env_pair.key, 'manylinux'), eq(env_pair.key, 'linux32'))) }}:
+            - ${{ if and(eq(tool_pair.key, 'yum'), variables.manylinux_image) }}:
               - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -23,8 +23,6 @@ jobs:
           # Setup python version
           ${{ if startsWith(env_pair.value, 'py27') }}:
             python: '2.7'
-          ${{ if startsWith(env_pair.value, 'py34') }}:
-            python: '3.4'
           ${{ if startsWith(env_pair.value, 'py35') }}:
             python: '3.5'
           ${{ if startsWith(env_pair.value, 'py36') }}:
@@ -40,8 +38,11 @@ jobs:
           ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
             manylinux_container: ${{ coalesce(env['manylinux_image'], 'manylinux2010_i686') }}
             manylinux_image: ${{ format('quay.io/pypa/{0}:latest', variables.manylinux_container) }}
-          ${{ if variables.python }}:
+          old_manylinux_path: or(contains(variables.python, '5'), contains(variables.python, '6'), contains(variables.python, '7'))
+          ${{ if eq(old_manylinux_path, 'true') }}:
             manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
+          ${{ if eq(old_manylinux_path, 'false') }}:
+            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
           docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinux_container) }}

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -38,14 +38,13 @@ jobs:
 
           # Docker and manylinux
           ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
-            default_manylinux_container: 'manylinux2010_i686'
-          manylinux_container: ${{ coalesce(env['manylinux_image'], variables.default_manylinux_container, '') }}
-          ${{ if variables.manylinux_container }}:
-            manylinux_image: format('quay.io/pypa/{0}:latest', variables.manylinux_container)
-          manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
+            manylinux_container: ${{ coalesce(env['manylinux_image'], 'manylinux2010_i686') }}
+            manylinux_image: ${{ format('quay.io/pypa/{0}:latest', variables.manylinux_container) }}
+          ${{ if variables.python }}:
+            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
-          docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinx_image) }}
+          docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinux_container) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'
@@ -59,7 +58,7 @@ jobs:
             pytest_flag: ''
 
         ${{ if variables.docker_image }}:
-          displayName: '${{ coalesce(env.name, env_pair.value) }} [docker ${{ variables.docker_image }}]'
+          displayName: '${{ coalesce(env.name, env_pair.value) }} [docker ${{ coalesce(variables.manylinux_container, variables.docker_image) }}]'
         ${{ if not(variables.docker_image) }}:
           displayName: ${{ variables.friendly_name }}
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -23,12 +23,16 @@ jobs:
           # Setup python version
           ${{ if startsWith(env_pair.value, 'py27') }}:
             python: '2.7'
+            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           ${{ if startsWith(env_pair.value, 'py35') }}:
             python: '3.5'
+            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           ${{ if startsWith(env_pair.value, 'py36') }}:
             python: '3.6'
+            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           ${{ if startsWith(env_pair.value, 'py37') }}:
             python: '3.7'
+            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           ${{ if startsWith(env_pair.value, 'py38') }}:
             python: '3.8'
           ${{ if startsWith(env_pair.value, 'py39') }}:
@@ -38,11 +42,9 @@ jobs:
           ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
             manylinux_container: ${{ coalesce(env['manylinux_image'], 'manylinux2010_i686') }}
             manylinux_image: ${{ format('quay.io/pypa/{0}:latest', variables.manylinux_container) }}
-          old_manylinux_path: ${{ or(contains(variables.python, '5'), contains(variables.python, '6'), contains(variables.python, '7')) }}
-          ${{ if eq(variables.old_manylinux_path, 'true') }}:
-            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
-          ${{ if eq(variables.old_manylinux_path, 'false') }}:
-            manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}/bin/python', replace(variables.python, '.', '')) }}
+            ${{ if not(variables.manylinux_python) }}:
+              manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}/bin/python', replace(variables.python, '.', '')) }}
+
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
           docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinux_container) }}

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -82,6 +82,8 @@ jobs:
           - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_image }} /bin/bash
             displayName: Start up Docker container
 
+        - bash: echo ${{ coalesce(env['libraries'], parameters.libraries) }}
+
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:
           - ${{ each library in tool_pair.value }}:
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -22,12 +22,13 @@ jobs:
 
           # Docker and manylinux
           ${{ if contains(env_pair.key, 'linux32_') }}:
-            manylinux_image: ${{ format('quay.io/pypa/{0}', replace(env_pair.key, 'linux32_', '')) }}
+            manylinux_image: ${{ replace(env_pair.key, 'linux32_', '') }}
           ${{ if eq(env_pair.key, 'linux32') }}:
-            manylinux_image: 'quay.io/pypa/manylinux2010_i686'
+            manylinux_image: 'manylinux2010_i686'
           manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(env_pair.value, 'py', '')) }}
           docker_python_exec: ${{ coalesce(parameters.docker_python, variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(parameters.docker_image, variables.manylinux_image, '') }}
+          docker_pull: ${{ coalesce(parameters.docker_pull, format('quay.io/pypa/{0}', variables.manylinux_image), variables.docker_image) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'
@@ -57,7 +58,7 @@ jobs:
           fetchDepth: 999999999
 
         - ${{ if variables.docker_image }}:
-          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_image }} -d ${{ variables.docker_image }}:latest /bin/bash
+          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_image }} -d ${{ variables.docker_pull }}:latest /bin/bash
             displayName: Start up Docker container
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -44,6 +44,7 @@ jobs:
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
           docker_pull: ${{ coalesce(env['docker_pull'], env['docker_image'], format('quay.io/pypa/{0}:latest', variables.manylinux_image)) }}
+          docker_name: ${{ coalesce(env['docker_name'], replace(variables.docker_image, ':', '_')) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'
@@ -76,7 +77,7 @@ jobs:
           fetchDepth: 999999999
 
         - ${{ if variables.docker_image }}:
-          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_image }} -d ${{ variables.docker_pull }} /bin/bash
+          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_pull }} /bin/bash
             displayName: Start up Docker container
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:
@@ -95,16 +96,17 @@ jobs:
                 displayName: Installing ${{ library }} with apt
 
             - ${{ if and(eq(tool_pair.key, 'yum'), eq(env_pair.key, 'linux32')) }}:
-              - script: docker exec -i -w /project ${{ variables.docker_image }} yum install -y ${{ library }}
+              - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 
             - ${{ if and(eq(tool_pair.key, 'choco'), eq(env_pair.key, 'windows')) }}:
               - script: choco install ${{ library }}
                 displayName: Installing ${{ library }} with choco
 
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: ${{ coalesce(variables['python'], '3.x') }}
+        - ${{ if not(variables.docker_image) }}:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: ${{ coalesce(variables['python'], '3.x') }}
 
         - ${{ if eq(variables.mesaopengl, 'true') }}:
 
@@ -152,10 +154,10 @@ jobs:
 
         - ${{ if variables.docker_image }}:
 
-          - script: docker exec -i -w /project ${{ variables.docker_image }} ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
+          - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox
 
-          - script: docker exec -i -w /project ${{ variables.docker_image }} ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
+          - script: docker exec -i -w /project ${{ variables.docker_name }} ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
             displayName: Running tox
 
         - ${{ if not(variables.docker_image) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -57,7 +57,7 @@ jobs:
             pytest_flag: ''
 
         ${{ if variables.docker_image }}:
-          displayName: '${{ coalesce(env.name, env_pair.value) }} [${{ variables.docker_image }}]'
+          displayName: '${{ coalesce(env.name, env_pair.value) }} [docker ${{ variables.docker_image }}]'
         ${{ if not(variables.docker_image) }}:
           displayName: ${{ variables.friendly_name }}
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -82,7 +82,7 @@ jobs:
           - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_image }} /bin/bash
             displayName: Start up Docker container
 
-        - bash: echo ${{ env['libraries']['yum'][0] }}
+        - bash: echo ${{ env['libraries']['yum'] }}
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:
           - ${{ each library in tool_pair.value }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -97,7 +97,7 @@ jobs:
               - script: sudo apt-get install -y ${{ library }}
                 displayName: Installing ${{ library }} with apt
 
-            - ${{ if and(eq(tool_pair.key, 'yum'), variables.manylinux_image) }}:
+            - ${{ if and(eq(tool_pair.key, 'yum'), or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux'))) }}:
               - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -8,7 +8,7 @@ jobs:
 - ${{ each env in parameters.envs }}:
   - ${{ each env_pair in env }}:
 
-    - ${{ if or(startsWith(env_pair.key, 'linux'), eq(env_pair, 'manylinux'), eq(env_pair.key, 'macos'), eq(env_pair.key, 'windows')) }}:
+    - ${{ if or(startsWith(env_pair.key, 'linux'), eq(env_pair.key, 'manylinux'), eq(env_pair.key, 'macos'), eq(env_pair.key, 'windows')) }}:
 
       - job: ${{ coalesce(env['name'], variables['Agent.Id']) }}
         variables:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -38,10 +38,10 @@ jobs:
           ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
             manylinux_container: ${{ coalesce(env['manylinux_image'], 'manylinux2010_i686') }}
             manylinux_image: ${{ format('quay.io/pypa/{0}:latest', variables.manylinux_container) }}
-          old_manylinux_path: or(contains(variables.python, '5'), contains(variables.python, '6'), contains(variables.python, '7'))
-          ${{ if eq(old_manylinux_path, 'true') }}:
+          old_manylinux_path: ${{ or(contains(variables.python, '5'), contains(variables.python, '6'), contains(variables.python, '7')) }}
+          ${{ if eq(variables.old_manylinux_path, 'true') }}:
             manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
-          ${{ if eq(old_manylinux_path, 'false') }}:
+          ${{ if eq(variables.old_manylinux_path, 'false') }}:
             manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -98,7 +98,7 @@ jobs:
               - script: sudo apt-get install -y ${{ library }}
                 displayName: Installing ${{ library }} with apt
 
-            - ${{ if and(eq(tool_pair.key, 'yum'), eq(env_pair.key, 'linux32')) }}:
+            - ${{ if and(eq(tool_pair.key, 'yum'), or(eq(env_pair.key, 'manylinux'), eq(env_pair.key, 'linux32'))) }}:
               - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -8,7 +8,7 @@ jobs:
 - ${{ each env in parameters.envs }}:
   - ${{ each env_pair in env }}:
 
-    - ${{ if or(startsWith(env_pair.key, 'linux32'), eq(env_pair.key, 'linux'), eq(env_pair.key, 'macos'), eq(env_pair.key, 'windows')) }}:
+    - ${{ if or(startsWith(env_pair.key, 'linux'), eq(env_pair, 'manylinux'), eq(env_pair.key, 'macos'), eq(env_pair.key, 'windows')) }}:
 
       - job: ${{ coalesce(env['name'], variables['Agent.Id']) }}
         variables:
@@ -37,14 +37,13 @@ jobs:
             python: '3.9'
 
           # Docker and manylinux
-          ${{ if eq(env_pair.key, 'linux32') }}:
+          ${{ if or(eq(env_pair.key, 'linux32'), eq(env_pair.key, 'manylinux')) }}:
             default_manylinux_image: 'manylinux2010_i686'
           manylinux_image: ${{ coalesce(env['manylinux_image'], variables.default_manylinux_image, '') }}
           manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
-          docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
-          docker_pull: ${{ coalesce(env['docker_pull'], env['docker_image'], format('quay.io/pypa/{0}:latest', variables.manylinux_image)) }}
-          docker_name: ${{ coalesce(env['docker_name'], replace(variables.docker_image, ':', '_')) }}
+          docker_image: ${{ coalesce(env['docker_image'], format('quay.io/pypa/{0}:latest', variables.manylinux_image), '') }}
+          docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinx_image) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'
@@ -77,7 +76,7 @@ jobs:
           fetchDepth: 999999999
 
         - ${{ if variables.docker_image }}:
-          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_pull }} /bin/bash
+          - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_image }} /bin/bash
             displayName: Start up Docker container
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -50,7 +50,7 @@ jobs:
 
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
-          docker_name: ${{ coalesce(env['docker_name'], replace(env['docker_image'], ':', '_'), variables.manylinux_container) }}
+          docker_name: ${{ coalesce(env['docker_name'], replace(replace(env['docker_image'], ':', '_'), '/', '_'), variables.manylinux_container) }}
 
           ${{ if eq(env_pair.key, 'windows') }}:
             source: 'call'

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -93,7 +93,7 @@ jobs:
                 displayName: Installing ${{ library }} with apt
 
             - ${{ if and(eq(tool_pair.key, 'yum'), eq(env_pair.key, 'linux32')) }}:
-              - script: docker exec -i -w /project ${{ variables.docker_image }} linux32 yum install -y ${{ library }}
+              - script: docker exec -i -w /project ${{ variables.docker_image }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 
             - ${{ if and(eq(tool_pair.key, 'choco'), eq(env_pair.key, 'windows')) }}:
@@ -150,10 +150,10 @@ jobs:
 
         - ${{ if variables.docker_image }}:
 
-          - script: docker exec -i -w /project ${{ variables.docker_image }} linux32 ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
+          - script: docker exec -i -w /project ${{ variables.docker_image }} ${{ variables.docker_python_exec }} -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox
 
-          - script: docker exec -i -w /project ${{ variables.docker_image }} linux32 ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
+          - script: docker exec -i -w /project ${{ variables.docker_image }} ${{ variables.docker_python_exec }} -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
             displayName: Running tox
 
         - ${{ if not(variables.docker_image) }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -37,10 +37,9 @@ jobs:
             python: '3.9'
 
           # Docker and manylinux
-          ${{ if contains(env_pair.key, 'linux32_') }}:
-            manylinux_image: ${{ replace(env_pair.key, 'linux32_', '') }}
           ${{ if eq(env_pair.key, 'linux32') }}:
-            manylinux_image: 'manylinux2010_i686'
+            default_manylinux_image: 'manylinux2010_i686'
+          manylinux_image: ${{ coalesce(env['manylinux_image'], variables.default_manylinux_image, '') }}
           manylinux_python: ${{ format('/opt/python/cp{0}-cp{0}m/bin/python', replace(variables.python, '.', '')) }}
           docker_python_exec: ${{ coalesce(env['docker_python'], variables.manylinux_python, '/opt/python/cp27-cp27m/bin/python') }}
           docker_image: ${{ coalesce(env['docker_image'], variables.manylinux_image, '') }}
@@ -57,12 +56,15 @@ jobs:
           ${{ if not(eq(variables.pytest, 'true')) }}:
             pytest_flag: ''
 
-        displayName: ${{ variables.friendly_name }}
+        ${{ if variables.docker_image }}:
+          displayName: '${{ coalesce(env.name, env_pair.value) }} [${{ variables.docker_image }}]'
+        ${{ if not(variables.docker_image) }}:
+          displayName: ${{ variables.friendly_name }}
 
         pool:
           ${{ if eq(env_pair.key, 'macos') }}:
             vmImage: macos-latest
-          ${{ if or(eq(env_pair.key, 'linux'), startsWith(env_pair.key, 'linux32')) }}:
+          ${{ if startsWith(env_pair.key, 'linux') }}:
             vmImage: ubuntu-latest
           ${{ if eq(env_pair.key, 'windows') }}:
             vmImage: windows-latest

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -82,8 +82,6 @@ jobs:
           - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_image }} /bin/bash
             displayName: Start up Docker container
 
-        - bash: echo ${{ env['libraries']['yum'] }}
-
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:
           - ${{ each library in tool_pair.value }}:
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -1,5 +1,4 @@
 parameters:
-  libraries: []
   envs: []
   coverage: false
   pytest: true
@@ -98,7 +97,7 @@ jobs:
               - script: sudo apt-get install -y ${{ library }}
                 displayName: Installing ${{ library }} with apt
 
-            - ${{ if and(eq(tool_pair.key, 'yum'), eq(env_pair.key, 'linux32')) }}:
+            - ${{ if and(eq(tool_pair.key, 'yum'), variables.manylinux_image) }}:
               - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -82,7 +82,7 @@ jobs:
           - bash: docker run -v $PWD:/project -i --name ${{ variables.docker_name }} -d ${{ variables.docker_image }} /bin/bash
             displayName: Start up Docker container
 
-        - bash: echo ${{ coalesce(env['libraries'], parameters.libraries) }}
+        - bash: echo ${{ env['libraries']['yum'][0] }}
 
         - ${{ each tool_pair in coalesce(env['libraries'], parameters.libraries) }}:
           - ${{ each library in tool_pair.value }}:

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -98,7 +98,7 @@ jobs:
               - script: sudo apt-get install -y ${{ library }}
                 displayName: Installing ${{ library }} with apt
 
-            - ${{ if and(eq(tool_pair.key, 'yum'), variables.manylinux_image) }}:
+            - ${{ if and(eq(tool_pair.key, 'yum'), eq(env_pair.key, 'linux32')) }}:
               - script: docker exec -i -w /project ${{ variables.docker_name }} yum install -y ${{ library }}
                 displayName: Installing ${{ library }} with yum
 


### PR DESCRIPTION
This started as an exercise in allowing sunpy to specify which manylinux image to use for our 32bit builds. However, it quickly spiralled into allowing any docker image. So you can now use it to do things like test compatibility with the rcs of CPython by using the official docker images (see test in our `azure-pipelines.yml`).