### PR TITLE
Use "python -m" to run tox

### DIFF
--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -172,7 +172,7 @@ jobs:
           - script: python -m pip install --upgrade tox ${{ variables.toxdeps }}
             displayName: Install tox
 
-          - script: tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
+          - script: python -m tox -e ${{ env_pair.value }} ${{ variables['toxargs'] }} -- ${{ variables['pytest_flag'] }} ${{ variables['posargs'] }}
             displayName: Running tox
             ${{ if eq(variables.xvfb, 'true') }}:
               env:


### PR DESCRIPTION
I am using `toxdeps: "git+https://github.com/tox-dev/tox.git@rewrite"` to install the dev version of tox, successfully. However, it fails because `tox` command does not exist anymore.

See https://dev.azure.com/poliastro/poliastro/_build/results?buildId=612&view=logs&j=0d2e6dee-4abd-58ce-47f1-cbb7d58969b6&t=bb178197-91f0-5356-52dc-6be51a8dfbd1&l=14

```
2021-01-01T22:41:34.9532072Z ##[section]Starting: Running tox
2021-01-01T22:41:34.9540150Z ==============================================================================
2021-01-01T22:41:34.9541195Z Task         : Command line
2021-01-01T22:41:34.9541575Z Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
2021-01-01T22:41:34.9541884Z Version      : 2.178.0
2021-01-01T22:41:34.9542114Z Author       : Microsoft Corporation
2021-01-01T22:41:34.9542800Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
2021-01-01T22:41:34.9543203Z ==============================================================================
2021-01-01T22:41:35.1000310Z Generating script.
2021-01-01T22:41:35.1009774Z Script contents:
2021-01-01T22:41:35.1010674Z tox -e check  -- --junitxml=junit/test-results.xml --cov-report=xml:/home/vsts/work/1/s/coverage.xml -vv
2021-01-01T22:41:35.1011309Z ========================== Starting Command Output ===========================
2021-01-01T22:41:35.1036893Z [command]/bin/bash --noprofile --norc /home/vsts/work/_temp/2c1908cd-5418-465e-8128-1344a6a07e0a.sh
2021-01-01T22:41:35.1105792Z /home/vsts/work/_temp/2c1908cd-5418-465e-8128-1344a6a07e0a.sh: line 1: tox: command not found
2021-01-01T22:41:35.1174160Z ##[error]Bash exited with code '127'.
2021-01-01T22:41:35.1215040Z ##[section]Finishing: Running tox
```