### PR TITLE
Use fork clone URL if fork

### DIFF
--- a/check-skip.sh
+++ b/check-skip.sh
@@ -72,6 +72,10 @@ get_commit_hash () {
 
 get_commit_message () {
   require_argument commit_hash "$1"
+  if [[ -n "$PR_NUMBER" ]]; then
+    echo "Fetching fork at PR #$PR_NUMBER"
+    git fetch origin "refs/pull/$PR_NUMBER/head"
+  fi
   MSG=$(git log --format=%B -n 1 "$1")
   if [ $? -ne 0 ]; then
     echo "Error running: git log --format=%B -n 1 $1" 1>&2

--- a/check-skip.yml
+++ b/check-skip.yml
@@ -9,6 +9,8 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - checkout: OpenAstronomy
+      path: s/azure-pipelines-templates
     - ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
       - bash: |
           QUERY="repos/$BUILD_REPOSITORY_NAME/pulls/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
@@ -19,8 +21,6 @@ jobs:
     - ${{ else }}:
       - checkout: self
         path: s/self
-    - checkout: OpenAstronomy
-      path: s/azure-pipelines-templates
     - bash: $(Pipeline.Workspace)/s/azure-pipelines-templates/check-skip.sh
       workingDirectory: $(Pipeline.Workspace)/s/self
       name: search

--- a/check-skip.yml
+++ b/check-skip.yml
@@ -9,8 +9,16 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-    - checkout: self
-      path: s/self
+    - ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
+      - bash: |
+          QUERY="repos/$BUILD_REPOSITORY_NAME/pulls/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
+          KEY=".head.repo.clone_url"
+          FORK_URL=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/$QUERY" | jq "$KEY")
+          git clone "$FORK_URL" "$(Pipeline.Workspace)/s/self"
+        displayName: Checkout fork to s/self
+    - ${{ else }}:
+      - checkout: self
+        path: s/self
     - checkout: OpenAstronomy
       path: s/azure-pipelines-templates
     - bash: $(Pipeline.Workspace)/s/azure-pipelines-templates/check-skip.sh

--- a/check-skip.yml
+++ b/check-skip.yml
@@ -13,7 +13,7 @@ jobs:
       - bash: |
           QUERY="repos/$BUILD_REPOSITORY_NAME/pulls/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
           KEY=".head.repo.clone_url"
-          FORK_URL=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/$QUERY" | jq "$KEY")
+          FORK_URL=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/$QUERY" | jq -r "$KEY")
           git clone "$FORK_URL" "$(Pipeline.Workspace)/s/self"
         displayName: Checkout fork to s/self
     - ${{ else }}:

--- a/check-skip.yml
+++ b/check-skip.yml
@@ -9,18 +9,10 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - checkout: self
+      path: s/self
     - checkout: OpenAstronomy
       path: s/azure-pipelines-templates
-    - ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
-      - bash: |
-          QUERY="repos/$BUILD_REPOSITORY_NAME/pulls/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
-          KEY=".head.repo.clone_url"
-          FORK_URL=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/$QUERY" | jq -r "$KEY")
-          git clone "$FORK_URL" "$(Pipeline.Workspace)/s/self"
-        displayName: Checkout fork to s/self
-    - ${{ else }}:
-      - checkout: self
-        path: s/self
     - bash: $(Pipeline.Workspace)/s/azure-pipelines-templates/check-skip.sh
       workingDirectory: $(Pipeline.Workspace)/s/self
       name: search
@@ -28,6 +20,8 @@ jobs:
         COMMIT_MESSAGE: $(Build.SourceVersionMessage)
         ${{ if parameters.commands }}:
           SKIP_COMMANDS: ${{ parameters.commands }}
+        ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
+          PR_NUMBER: $(System.PullRequest.PullRequestNumber)
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - bash: echo "##vso[task.setvariable variable=found;isOutput=true]false"
       name: search


### PR DESCRIPTION
When using the `check_skip.yml` template on a PR from a fork it can't find the commit hash in the `self` repository Azure checks out. This PR is to use the GitHub API to get the clone URL of the fork and clone that instead of the target repository. Testing at https://github.com/sunpy/sunpy/pull/5700.