### PR TITLE
Update docs on specifying custom skip commands

### DIFF
--- a/docs/check_skip.rst
+++ b/docs/check_skip.rst
@@ -99,7 +99,8 @@ This default list can be replaced as shown in the following code.
     - stage: StageOne
       jobs:
       - template: check-skip.yml@OpenAstronomy
-        commands: '"[skip ci]" "[ci skip]" noci'
+        parameters:
+          commands: '"[skip ci]" "[ci skip]" noci'
 
 This will configure the check to only recognise ``[skip ci]``, ``[ci skip]``
 and ``noci`` as valid skip commands.


### PR DESCRIPTION
Parameters for templates need to be specified within the value of the `parameters` key.