### PR TITLE
Update documentation on specifying a ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-### Python: https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
+### Python: https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -108,7 +108,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 
-### https://raw.github.com/github/gitignore/master/Global/OSX.gitignore
+### https://raw.github.com/github/gitignore/main/Global/OSX.gitignore
 
 .DS_Store
 .AppleDouble
@@ -125,7 +125,7 @@ Icon
 .Spotlight-V100
 .Trashes
 
-### Linux: https://raw.githubusercontent.com/github/gitignore/master/Global/Linux.gitignore
+### Linux: https://raw.githubusercontent.com/github/gitignore/main/Global/Linux.gitignore
 
 *~
 
@@ -141,7 +141,7 @@ Icon
 # .nfs files are created when an open file is removed but is still being accessed
 .nfs*
 
-### MacOS: https://raw.githubusercontent.com/github/gitignore/master/Global/macOS.gitignore
+### MacOS: https://raw.githubusercontent.com/github/gitignore/main/Global/macOS.gitignore
 
 # General
 .DS_Store
@@ -171,7 +171,7 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-### Windows: https://raw.githubusercontent.com/github/gitignore/master/Global/Windows.gitignore
+### Windows: https://raw.githubusercontent.com/github/gitignore/main/Global/Windows.gitignore
 
 # Windows thumbnail cache files
 Thumbs.db
@@ -197,7 +197,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-### VScode: https://raw.githubusercontent.com/github/gitignore/master/Global/VisualStudioCode.gitignore
+### VScode: https://raw.githubusercontent.com/github/gitignore/main/Global/VisualStudioCode.gitignore
 .vscode/*
 
 ### Extra Python Items and SunPy Specific

--- a/docs/common.rst
+++ b/docs/common.rst
@@ -26,10 +26,14 @@ To load the template, add the following to the beginning of the ``azure-pipeline
         type: github
         endpoint: <service connection name>
         name: OpenAstronomy/azure-pipelines-templates
-        ref: master
 
 where ``<service connection name>`` is the name of the service connection you
 set up above. This will make the templates in this repository available in the
-``OpenAstronomy`` namespace in the rest of the file. Note the ref allows you to
-pin the template version you want, you can use ``master`` if you want the latest
-version.
+``OpenAstronomy`` namespace in the rest of the file.
+
+.. note::
+   Specifying the ``ref`` property for the ``OpenAstronomy`` repository is not
+   recommended because the default branch of the ``azure-pipelines-templates``
+   repository may change in the future.
+   `Azure Pipelines will use the current default branch when a ref is not specified.
+   <https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checking-out-a-specific-ref>`__

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -200,14 +200,14 @@ If you want to make this feed public, so that unauthenticated users can access i
 To upload to Azure Artifacts rather than PyPI, you specify the ``artifact_feed`` and ``artifact_project`` variables instead of ``pypi_connection_name``.
 
 
-If you wish to upload on all builds on master you would add a section to the ``publish.yml`` config which looks like:
+If you wish to upload on all builds on the branch ``main`` you would add a section to the ``publish.yml`` config which looks like:
 
 .. code:: yaml
 
     jobs:
     - template: publish.yml@OpenAstronomy
       parameters:
-        ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+        ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
           artifact_project : 'projectname'
           artifact_feed : 'feedname'
         ...
@@ -255,7 +255,7 @@ Using this your config block would look like:
     jobs:
     - template: publish.yml@OpenAstronomy
       parameters:
-        ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+        ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
           artifact_project : 'projectname'
           artifact_feed : 'feedname'
           remove_local_scheme: true

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -8,7 +8,7 @@ want to find out about how to use the templates, you can jump ahead to
 Before we start setting up Azure Pipelines, we need to make sure that an
 ``azure-pipelines.yml`` file exists somewhere in the main (upstream) repository
 you are setting up. This can be problematic in that you may not want to add a
-configuration file to your ``master`` branch until you know it works properly.
+configuration file to your default branch until you know it works properly.
 Instead, you will likely want to create the configuration file in a branch of
 your fork, and then iterate on it in a pull request to your main repository.
 


### PR DESCRIPTION
As discussed in #64, this PR removes the recommendation to specify a ref for `OpenAstronomy/azure-pipelines-templates` since Azure Pipelines will use its default branch if omitted.