### PR TITLE
Always fetch PR head

### DIFF
--- a/check-skip.sh
+++ b/check-skip.sh
@@ -73,7 +73,7 @@ get_commit_hash () {
 get_commit_message () {
   require_argument commit_hash "$1"
   if [[ -n "$PR_NUMBER" ]]; then
-    echo "Fetching fork at PR #$PR_NUMBER"
+    echo "Fetching refs/pull/$PR_NUMBER/head"
     git fetch origin "refs/pull/$PR_NUMBER/head"
   fi
   MSG=$(git log --format=%B -n 1 "$1")

--- a/check-skip.yml
+++ b/check-skip.yml
@@ -18,10 +18,9 @@ jobs:
       name: search
       env:
         COMMIT_MESSAGE: $(Build.SourceVersionMessage)
+        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
         ${{ if parameters.commands }}:
           SKIP_COMMANDS: ${{ parameters.commands }}
-        ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
-          PR_NUMBER: $(System.PullRequest.PullRequestNumber)
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - bash: echo "##vso[task.setvariable variable=found;isOutput=true]false"
       name: search


### PR DESCRIPTION
It was noticed at https://github.com/sunpy/sunpy/pull/5814 that `check_skip` is not fetching deep enough anymore. According to [Azure docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#checkout), the default depth is unlimited, however, `--depth=1` is appearing in fetch commands. This PR always passes the `PR_NUMBER` env var to `check_skip.sh` so it always fetches the head of the PR. (This was already the default for PRs from forks.) I have tested this fix locally using the git commands shown in the Azure log.