### PR TITLE
Use Bash to install tox-conda on Windows

### DIFF
--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -182,7 +182,7 @@ jobs:
               conda install --yes --quiet --name testenv python=${{ variables.python }} pip
             displayName: Create and activate conda env
 
-          - script: python -m pip install --upgrade 'tox-conda!=0.8.0' ${{ variables.toxdeps }}
+          - bash: python -m pip install --upgrade 'tox-conda!=0.8.0' ${{ variables.toxdeps }}
             displayName: install tox-conda
 
         - ${{ if variables.docker_image }}:


### PR DESCRIPTION
On Linux and macOS runners `script` already runs as `bash`, however on windows it runs with `cmd.exe`. This is to fix the error at https://github.com/sunpy/sunkit-image/pull/77 which is probably due to single quotes not being special in cmd.exe.