### PR TITLE
Also replace curly brackets and commas in job names

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ jobs:
 
   - ${{ if and(startsWith(target, 'wheels_'),ne(target, 'wheels_universal')) }}:
 
-    - job: ${{ replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_') }}
+    - job: ${{ replace(replace(replace(replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_'), '{', ''), '}', ''), ',', '') }}
       displayName: ${{ target }}
       dependsOn: ${{ parameters.dependsOn }}
       condition: succeeded()
@@ -16,7 +16,7 @@ jobs:
         CIBW_TEST_COMMAND: ${{ parameters.test_command }}
         CIBW_TEST_EXTRAS: ${{ parameters.test_extras }}
         OA_TARGET: ${{ target }}
-        job_name: ${{ replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_') }}
+        job_name: ${{ replace(replace(replace(replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_'), '{', ''), '}', ''), ',', '') }}
         ${{ if contains(target, 'macos') }}:
           os: 'macos'
         ${{ if contains(target, 'win') }}:
@@ -173,7 +173,7 @@ jobs:
 
     dependsOn:
     - ${{ each target in parameters.targets }}:
-      - ${{ replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_') }}
+      - ${{ replace(replace(replace(replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_'), '{', ''), '}', ''), ',', '') }}
 
     condition: succeeded()
 
@@ -195,7 +195,7 @@ jobs:
           inputs:
             buildType: 'current'
             targetPath: 'wheelhouse'
-            artifactName: ${{ replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_') }}
+            artifactName: ${{ replace(replace(replace(replace(replace(replace(replace(replace(replace(target, '?', ''), '*', ''), '[', ''), ']', ''), '!', ''), '-', '_'), '{', ''), '}', ''), ',', '') }}
 
     - script: 'ls -R wheelhouse'
       displayName: "List files for upload"


### PR DESCRIPTION
In order to support specifying cibuildwheel jobs such as `wheels_cp3{9,10,11}-manylinux*_x86_64`, the characters `{`, `}` and `,` must also be removed from the job name displayed by Azure Pipelines. This template can already handle `wheels_cp3[7-9]-manylinux*_x86_64` etc. but now with double digit versions, we also need to handle curly brackets and commas.